### PR TITLE
support async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change log
 
+## Version 2.1.0
+戻り値がfunction型のメソッドをRPC時は, そのfunctionの第一引数をコールバックする仕様に変更する。
+
 ## Version 2.0.0
 初版

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change log
 
 ## Version 2.1.0
-戻り値がfunction型のメソッドをRPC時は, そのfunctionの第一引数をコールバックする仕様に変更する。
+- 戻り値がfunction型のメソッドをRPC時は, そのfunctionの第一引数をコールバックする仕様に変更する
+  - 詳細は https://github.com/cross-border-bridge/function-channel/pull/1 を参照
 
 ## Version 2.0.0
 初版

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change log
 
 ## Version 2.1.0
-- 戻り値がfunction型のメソッドをRPC時は, そのfunctionの第一引数をコールバックする仕様に変更する
+- 戻り値がfunction型のメソッドをRPC時は, そのfunctionの第一引数で戻り値をコールバックする仕様に変更
   - 詳細は https://github.com/cross-border-bridge/function-channel/pull/1 を参照
 
 ## Version 2.0.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### package.json
 ```
     "dependencies": {
-        "@cross-border-bridge/function-channel": "~2.0.0"
+        "@cross-border-bridge/function-channel": "~2.1.0"
     },
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "vinyl-source-stream": "^1.1.0",
     "gulp-jasmine": "~2.4.1",
     "gulp-istanbul": "~1.1.1",
-    "typescript": "1.8.10"
+    "typescript": "1.8.10",
+    "@cross-border-bridge/memory-queue-data-bus": "~2.0.0"
   },
   "files": [
     "lib"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cross-border-bridge/function-channel",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "FunctionChannel for Web application",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/FunctionChannel.ts
+++ b/src/FunctionChannel.ts
@@ -126,7 +126,7 @@ class FunctionChannel {
         }
         var result: any = this._bindingObjects[id][methodName](...args);
         if (callback) {
-            if (!!(result && result.constructor && result.call && result.apply)) {
+            if (typeof result === "function") {
                 result(function(r: any) {
                     callback([FMT_EDO, r]);
                 });

--- a/src/FunctionChannel.ts
+++ b/src/FunctionChannel.ts
@@ -125,6 +125,14 @@ class FunctionChannel {
             return;
         }
         var result: any = this._bindingObjects[id][methodName](...args);
-        if (callback) callback([FMT_EDO, result]);
+        if (callback) {
+            if (!!(result && result.constructor && result.call && result.apply)) {
+                result(function(r: any) {
+                    callback([FMT_EDO, r]);
+                });
+            } else {
+                callback([FMT_EDO, result]);
+            }
+        }
     }
 }


### PR DESCRIPTION
iOS版にある非同期版の関数を定義する機能をJS版でも使えるようにします。
同じインタフェースで各環境用の実装が書けるように、機能を揃えるのが目的です。

実装的には `Promise` を要求する方が正しいかもしれませんが、依存性関係など面倒臭いかなと思い、ひとまずコールバック関数を返した場合は非同期で動くようにして見ました。